### PR TITLE
JIRA: VZ-7896 add env vars to ensure git is executable

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 
 func run(c *cli.Context) {
 	logrus.Info("Starting controller")
+	logrus.Infof("Environment: %v", os.Environ())
 	ctx := signals.SetupSignalHandler(context.Background())
 
 	if c.Bool("debug") {

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 
 func run(c *cli.Context) {
 	logrus.Info("Starting controller")
-	logrus.Infof("Environment: %v", os.Environ())
+	logrus.Debugf("Environment: %v", os.Environ())
 	ctx := signals.SetupSignalHandler(context.Background())
 
 	if c.Bool("debug") {

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -15,5 +15,8 @@ RUN yum -y update && \
 COPY bin/gitjob /usr/bin/
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt SECURITY.md /licenses/
 
+# Update PATH to make sure git 2.27 is on the path
+ENV PATH="/opt/rh/rh-git227/root/usr/bin:${PATH}"
+
 USER 1000
 CMD ["gitjob"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -15,7 +15,7 @@ RUN yum -y update && \
 COPY bin/gitjob /usr/bin/
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt SECURITY.md /licenses/
 
-# Update PATH to make sure git 2.27 is on the path
+# Update env vars to make sure git 2.27 is executable
 ENV PATH=/opt/rh/rh-git227/root/usr/bin:${PATH}
 ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 ENV PERL5LIB=/opt/rh/rh-git227/root/usr/share/perl5/vendor_perl:${PERL5LIB:+:${PERL5LIB}}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,7 +16,9 @@ COPY bin/gitjob /usr/bin/
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt SECURITY.md /licenses/
 
 # Update PATH to make sure git 2.27 is on the path
-ENV PATH="/opt/rh/rh-git227/root/usr/bin:${PATH}"
+ENV PATH=/opt/rh/rh-git227/root/usr/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV PERL5LIB=/opt/rh/rh-git227/root/usr/share/perl5/vendor_perl:${PERL5LIB:+:${PERL5LIB}}
 
 USER 1000
 CMD ["gitjob"]


### PR DESCRIPTION
Add to PATH, PERL5LIB, and LD_LIBRARY_PATH to ensure that the exec (which does no inherit shell env) succeeds.