### PR TITLE
VZ-10440: Use ENTRYPOINT instead of CMD in docker build

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -21,4 +21,4 @@ ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRA
 ENV PERL5LIB=/opt/rh/rh-git227/root/usr/share/perl5/vendor_perl:${PERL5LIB:+:${PERL5LIB}}
 
 USER 1000
-CMD gitjob
+ENTRYPOINT ["gitjob"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -21,4 +21,4 @@ ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRA
 ENV PERL5LIB=/opt/rh/rh-git227/root/usr/share/perl5/vendor_perl:${PERL5LIB:+:${PERL5LIB}}
 
 USER 1000
-CMD ["gitjob"]
+CMD gitjob


### PR DESCRIPTION
This change was to resolve this error for the gitjob deployment:

failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "--tekton-image": executable file not found in $PATH: unknown